### PR TITLE
The label for the column should just be the column name

### DIFF
--- a/app/components/tabelle/index.jsx
+++ b/app/components/tabelle/index.jsx
@@ -53,7 +53,7 @@ export function TabelleHeader({ name, label, shortLabel, value, sorted }) {
   );
 
   return (
-    <th scope="col" role="columnheader" aria-label={`Sort and filter ${label}`}>
+    <th scope="col" role="columnheader" aria-label={label}>
       <div class="tabelle-header">
         <span
           class={`header ${shortLabel ? "" : "truncatable"}`}


### PR DESCRIPTION
The label for the column should just be the column name because it is also read out for each cell when using a screenreader